### PR TITLE
Fixed Beaver Breeding

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.1+build.10
 loader_version=0.16.9
 
 # Mod Properties
-mod_version=1.20-0.6.1
+mod_version=1.20-0.6.2
 maven_group=net.emilsg.clutter
 archives_base_name=clutter
 

--- a/src/main/java/net/emilsg/clutter/entity/custom/BeaverEntity.java
+++ b/src/main/java/net/emilsg/clutter/entity/custom/BeaverEntity.java
@@ -18,13 +18,13 @@ import net.minecraft.entity.mob.PathAwareEntity;
 import net.minecraft.entity.passive.AnimalEntity;
 import net.minecraft.entity.passive.PassiveEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.tag.BlockTags;
+import net.minecraft.registry.tag.ItemTags;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.ActionResult;
@@ -40,13 +40,11 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.List;
 
 public class BeaverEntity extends ClutterAnimalEntity {
     private static final TrackedData<BlockPos> HOME_POS = DataTracker.registerData(BeaverEntity.class, TrackedDataHandlerRegistry.BLOCK_POS);
 
-    private static final Ingredient BREEDING_INGREDIENT = getIngredientWithName("sapling");
+    private static final Ingredient BREEDING_INGREDIENT = Ingredient.fromTag(ItemTags.SAPLINGS);
 
     public final AnimationState waterAnimationState = new AnimationState();
     public final AnimationState idleAnimationState = new AnimationState();
@@ -65,19 +63,6 @@ public class BeaverEntity extends ClutterAnimalEntity {
         this.setPathfindingPenalty(PathNodeType.WATER, 0.0F);
         this.waterNavigation = new SwimNavigation(this, world);
         this.landNavigation = new MobNavigation(this, world);
-    }
-
-    private static Ingredient getIngredientWithName(String name) {
-        List<Item> items = new ArrayList<>();
-
-        Registries.ITEM.forEach(item -> {
-            Identifier id = Registries.ITEM.getId(item);
-            if (id.getPath().contains(name)) {
-                items.add(item);
-            }
-        });
-
-        return Ingredient.ofItems(items.toArray(new Item[0]));
     }
 
     public static DefaultAttributeContainer.Builder setAttributes() {
@@ -194,6 +179,10 @@ public class BeaverEntity extends ClutterAnimalEntity {
     @Override
     public ActionResult interactMob(PlayerEntity player, Hand hand) {
         ItemStack stackInHand = player.getStackInHand(hand);
+
+        if (this.isBreedingItem(stackInHand)) {
+            return super.interactMob(player, hand);
+        }
 
         String itemID = Registries.ITEM.getId(stackInHand.getItem()).toString();
         Block heldBlock = Block.getBlockFromItem(stackInHand.getItem());

--- a/src/main/resources/data/minecraft/tags/items/saplings.json
+++ b/src/main/resources/data/minecraft/tags/items/saplings.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "clutter:kiwi_tree_sapling",
+    "clutter:redwood_sapling"
+  ]
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -7,6 +7,9 @@
 	"authors": [
 		"EmilSG"
 	],
+	"contributors": [
+		"Michael Bartosh"
+	],
 	"contact": {
 		"homepage": "https://modrinth.com/mod/clutter",
 		"issues": "https://github.com/EmilsGithub/Clutter-Mod-Repository/issues",
@@ -53,8 +56,5 @@
 		],
 		"java": ">=17",
 		"fabric-api": "*"
-	},
-	"suggests": {
-		"another-mod": "*"
 	}
 }


### PR DESCRIPTION
- Fixed Beavers not being able to breed
   - Simplified their `BREEDING_INGREDIENT` logic a bit by changing it to a tag system
   - Ensured we check if the item is a breeding item on interact so we can continue with breeding logic
   - With this I also added all saplings Clutter adds to the saplings tag
- Version bump from `0.6.1` -> `0.6.2`, although I just realized that would conflict with the branch name.